### PR TITLE
Added OVERRIDE_DEPENDENCIES flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ USER_HELP = 'User that will own the application and has permission to write to c
 GROUP_DEFAULT = 'loris'
 GROUP_HELP = 'Group that will own the application and has permission to write to caches. [Default: %s]' % (USER_DEFAULT,)
 
+OVERRIDE_DEPENDENCIES = bool(os.environ.get('OVERRIDE_LORIS_DEPENDENCIES', False))
+
 DEPENDENCIES = [
     # (package, version, module)
     ('werkzeug', '>=0.8.3', 'werkzeug'),
@@ -219,11 +221,13 @@ application = create_app(config_file_path='%s')
         config.write()
 
 install_requires = []
-for d in DEPENDENCIES:
-    try:
-        __import__(d[2], fromlist=[''])
-    except ImportError:
-        install_requires.append(''.join(d[0:2]))
+
+if not OVERRIDE_DEPENDENCIES:
+    for d in DEPENDENCIES:
+        try:
+            __import__(d[2], fromlist=[''])
+        except ImportError:
+            install_requires.append(''.join(d[0:2]))
 
 def _read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()

--- a/setup.py
+++ b/setup.py
@@ -55,17 +55,10 @@ USER_HELP = 'User that will own the application and has permission to write to c
 GROUP_DEFAULT = 'loris'
 GROUP_HELP = 'Group that will own the application and has permission to write to caches. [Default: %s]' % (USER_DEFAULT,)
 
-OVERRIDE_DEPENDENCIES = bool(os.environ.get('OVERRIDE_LORIS_DEPENDENCIES', False))
 
-DEPENDENCIES = [
-    # (package, version, module)
-    ('werkzeug', '>=0.8.3', 'werkzeug'),
-    ('pillow', '>=2.4.0', 'PIL'),
-    ('configobj', '>=4.7.2,<=5.0.0', 'configobj'),
-    ('requests', '>=2.12.0', 'requests'),
-    ('mock', '==1.0.1', 'mock'),
-    ('responses', '==0.3.0', 'responses')
-]
+with open('requirements.txt') as f:
+    DEPENDENCIES = f.read().splitlines()
+
 if version_info[1] < 7:
     DEPENDENCIES.append(('ordereddict','>=1.1','ordereddict'))
 
@@ -220,14 +213,6 @@ application = create_app(config_file_path='%s')
         config.filename = config_file_target
         config.write()
 
-install_requires = []
-
-if not OVERRIDE_DEPENDENCIES:
-    for d in DEPENDENCIES:
-        try:
-            __import__(d[2], fromlist=[''])
-        except ImportError:
-            install_requires.append(''.join(d[0:2]))
 
 def _read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
@@ -243,7 +228,7 @@ setup(
     license='Simplified BSD',
     version=VERSION,
     packages=['loris'],
-    install_requires=install_requires
+    install_requires=DEPENDENCIES
 )
 
 


### PR DESCRIPTION
This will allow you to skip the installation of the required dependancies via an environment variable being present on the target OS and leave it down to the user to install them before hand.

In the long term I can extend the custom `cmdclass` that is already defined in the `setup.py` to allow similar behaviour. Though at present the `install_requires` list of dependancy strings is created outside of this class and applied directly to the `setup` function. This makes it difficult to integrate with so that logic could be moved into the `cmdclass` to tidy it up and allow for overriding.